### PR TITLE
Add uglifier gem needed for Heroku deployment

### DIFF
--- a/hello_app/Gemfile_final
+++ b/hello_app/Gemfile_final
@@ -8,7 +8,7 @@ gem 'webpacker',  '4.0.7'
 gem 'turbolinks', '5.2.0'
 gem 'jbuilder',   '2.9.1'
 gem 'bootsnap',   '1.4.4', require: false
-gem 'uglifier',   '4.2.0'
+gem 'uglifier',   '2.7.2'
 
 group :development, :test do
   gem 'sqlite3', '1.4.1'

--- a/hello_app/Gemfile_final
+++ b/hello_app/Gemfile_final
@@ -8,6 +8,7 @@ gem 'webpacker',  '4.0.7'
 gem 'turbolinks', '5.2.0'
 gem 'jbuilder',   '2.9.1'
 gem 'bootsnap',   '1.4.4', require: false
+gem 'uglifier',   '4.2.0'
 
 group :development, :test do
   gem 'sqlite3', '1.4.1'


### PR DESCRIPTION
Uglifier gem is needed to push to heroku

```
$ git push heroku master

[ . . . bundle install succeeds . . . assets precompile . . . ]

remote:        [4/4] Building fresh packages...                                                                                                                                   
remote:        Done in 21.57s.                                                                                                                                                    
remote:        rake aborted!                                                                                                                                                      
remote:        LoadError: cannot load such file -- uglifier

[ . . . stacktrace . . . ]
```

Adding this gem solves this error and heroku push is successful