### PR TITLE
update rails-controller-testing 1.0.4 to 1.0.5

### DIFF
--- a/sample_app/Gemfile
+++ b/sample_app/Gemfile
@@ -33,7 +33,7 @@ group :test do
   gem 'capybara',                 '3.35.3'
   gem 'selenium-webdriver',       '3.142.7'
   gem 'webdrivers',               '4.6.0'
-  gem 'rails-controller-testing', '1.0.4'
+  gem 'rails-controller-testing', '1.0.5'
   gem 'minitest',                 '5.11.3'
   gem 'minitest-reporters',       '1.3.8'
   gem 'guard',                    '2.16.2'

--- a/sample_app/Gemfile_initial
+++ b/sample_app/Gemfile_initial
@@ -25,7 +25,7 @@ group :test do
   gem 'capybara',                 '3.35.3'
   gem 'selenium-webdriver',       '3.142.7'
   gem 'webdrivers',               '4.6.0'
-  gem 'rails-controller-testing', '1.0.4'
+  gem 'rails-controller-testing', '1.0.5'
   gem 'minitest',                 '5.11.3'
   gem 'minitest-reporters',       '1.3.8'
   gem 'guard',                    '2.16.2'


### PR DESCRIPTION
Issue: 
```
jhunhong@msipc:~/RailsProject/sample_app (updating-users)$ rails test
Running via Spring preloader in process 69893
Started with run options --seed 34837

ERROR["test_should_redirect_update_when_not_logged_in", #<Minitest::Reporters::Suite:0x000055a87ed21960 @name="UsersControllerTest">, 0.07028385699959472]
 test_should_redirect_update_when_not_logged_in#UsersControllerTest (0.07s)
ArgumentError:         ArgumentError: wrong number of arguments (given 2, expected 1)
            test/controllers/users_controller_test.rb:21:in `block in <class:UsersControllerTest>'

  32/32: [=====================================] 100% Time: 00:00:01, Time: 00:00:01

Finished in 1.20572s
32 tests, 87 assertions, 0 failures, 1 errors, 0 skips
```
Related issue tracker: https://github.com/rspec/rspec-rails/issues/2446 

Issue status: Resolved after changing "rails-controller-testing" 1.0.4 to 1.0.5