### PR TITLE
Specify ruby version

### DIFF
--- a/hello_app/Gemfile
+++ b/hello_app/Gemfile
@@ -1,6 +1,8 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
+ruby '2.7.2'
+
 gem 'rails',      '6.1.4.1'
 gem 'puma',       '5.3.1'
 gem 'sass-rails', '6.0.0'

--- a/hello_app/Gemfile
+++ b/hello_app/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby '2.7.2'
+ruby '2.7.4'
 
 gem 'rails',      '6.1.4.1'
 gem 'puma',       '5.3.1'

--- a/hello_app/Gemfile_final
+++ b/hello_app/Gemfile_final
@@ -1,6 +1,8 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
+ruby '2.7.2'
+
 gem 'rails',      '6.1.4.1'
 gem 'puma',       '5.3.1'
 gem 'sass-rails', '6.0.0'

--- a/hello_app/Gemfile_final
+++ b/hello_app/Gemfile_final
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby '2.7.2'
+ruby '2.7.4'
 
 gem 'rails',      '6.1.4.1'
 gem 'puma',       '5.3.1'

--- a/sample_app/Gemfile
+++ b/sample_app/Gemfile
@@ -1,6 +1,8 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
+ruby '2.7.2'
+
 gem 'rails',                      '6.1.4.1'
 gem 'image_processing',           '1.9.3'
 gem 'mini_magick',                '4.9.5'

--- a/sample_app/Gemfile
+++ b/sample_app/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby '2.7.2'
+ruby '2.7.4'
 
 gem 'rails',                      '6.1.4.1'
 gem 'image_processing',           '1.9.3'

--- a/sample_app/Gemfile_initial
+++ b/sample_app/Gemfile_initial
@@ -1,6 +1,8 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
+ruby '2.7.2'
+
 gem 'rails',      '6.1.4.1'
 gem 'puma',       '5.3.1'
 gem 'sass-rails', '6.0.0'

--- a/sample_app/Gemfile_initial
+++ b/sample_app/Gemfile_initial
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby '2.7.2'
+ruby '2.7.4'
 
 gem 'rails',      '6.1.4.1'
 gem 'puma',       '5.3.1'

--- a/toy_app/Gemfile
+++ b/toy_app/Gemfile
@@ -1,6 +1,8 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
+ruby '2.7.2'
+
 gem 'rails',      '6.1.4.1'
 gem 'puma',       '5.3.1'
 gem 'sass-rails', '6.0.0'

--- a/toy_app/Gemfile
+++ b/toy_app/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby '2.7.2'
+ruby '2.7.4'
 
 gem 'rails',      '6.1.4.1'
 gem 'puma',       '5.3.1'


### PR DESCRIPTION
Deploying to heroku fails (attempting to use Ruby 3.0.0) with the current Gemfiles. Specifying the ruby version resolves this issue.

Error from Heroku:

```
remote: -----> Installing node-v16.13.1-linux-x64
remote: -----> Installing yarn-v1.22.17
remote: -----> Detecting rake tasks
remote: 
remote:  !
remote:  !     Could not detect rake tasks
remote:  !     ensure you can run `$ bundle exec rake -P` against your app
remote:  !     and using the production group of your Gemfile.
remote:  !     rake aborted!
remote:  !     TypeError: wrong argument type false (expected Symbol)
remote:  !     /tmp/build_9429930b/vendor/bundle/ruby/3.0.0/gems/bootsnap-1.7.2/lib/bootsnap/compile_cache/iseq.rb:13:in `to_binary'
remote:  !     /tmp/build_9429930b/vendor/bundle/ruby/3.0.0/gems/bootsnap-1.7.2/lib/bootsnap/compile_cache/iseq.rb:13:in `input_to_storage'
remote:  !     /tmp/build_9429930b/vendor/bundle/ruby/3.0.0/gems/bootsnap-1.7.2/lib/bootsnap/compile_cache/iseq.rb:30:in `fetch'
remote:  !     /tmp/build_9429930b/vendor/bundle/ruby/3.0.0/gems/bootsnap-1.7.2/lib/bootsnap/compile_cache/iseq.rb:30:in `fetch'
remote:  !     /tmp/build_9429930b/vendor/bundle/ruby/3.0.0/gems/bootsnap-1.7.2/lib/bootsnap/compile_cache/iseq.rb:55:in `load_iseq'
remote:  !     /tmp/build_9429930b/vendor/bundle/ruby/3.0.0/gems/bootsnap-1.7.2/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:23:in `require'
remote:  !     /tmp/build_9429930b/vendor/bundle/ruby/3.0.0/gems/bootsnap-1.7.2/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:23:in `block in require_with_bootsnap_lfi'
remote:  !     /tmp/build_9429930b/vendor/bundle/ruby/3.0.0/gems/bootsnap-1.7.2/lib/bootsnap/load_path_cache/loaded_features_index.rb:92:in `register'
remote:  !     /tmp/build_9429930b/vendor/bundle/ruby/3.0.0/gems/bootsnap-1.7.2/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:22:in `require_with_bootsnap_lfi'
remote:  !     /tmp/build_9429930b/vendor/bundle/ruby/3.0.0/gems/bootsnap-1.7.2/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:31:in `require'
remote:  !     /tmp/build_9429930b/vendor/bundle/ruby/3.0.0/gems/zeitwerk-2.5.4/lib/zeitwerk/kernel.rb:35:in `require'
remote:  !     /tmp/build_9429930b/vendor/bundle/ruby/3.0.0/gems/activesupport-6.1.4.1/lib/active_support/dependencies.rb:332:in `block in require'
remote:  !     /tmp/build_9429930b/vendor/bundle/ruby/3.0.0/gems/activesupport-6.1.4.1/lib/active_support/dependencies.rb:299:in `load_dependency'
remote:  !     /tmp/build_9429930b/vendor/bundle/ruby/3.0.0/gems/activesupport-6.1.4.1/lib/active_support/dependencies.rb:332:in `require'
remote:  !     /tmp/build_9429930b/vendor/bundle/ruby/3.0.0/gems/bootsnap-1.7.2/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:53:in `require_relative'
remote:  !     /tmp/build_9429930b/vendor/bundle/ruby/3.0.0/gems/thor-1.2.1/lib/thor/group.rb:1:in `<main>'
remote:  !     /tmp/build_9429930b/vendor/bundle/ruby/3.0.0/gems/bootsnap-1.7.2/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:23:in `require'
remote:  !     /tmp/build_9429930b/vendor/bundle/ruby/3.0.0/gems/bootsnap-1.7.2/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:23:in `block in require_with_bootsnap_lfi'
remote:  !     /tmp/build_9429930b/vendor/bundle/ruby/3.0.0/gems/bootsnap-1.7.2/lib/bootsnap/load_path_cache/loaded_features_index.rb:92:in `register'
remote:  !     /tmp/build_9429930b/vendor/bundle/ruby/3.0.0/gems/bootsnap-1.7.2/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:22:in `require_with_bootsnap_lfi'
remote:  !     /tmp/build_9429930b/vendor/bundle/ruby/3.0.0/gems/bootsnap-1.7.2/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:31:in `require'
remote:  !     /tmp/build_9429930b/vendor/bundle/ruby/3.0.0/gems/zeitwerk-2.5.4/lib/zeitwerk/kernel.rb:35:in `require'
remote:  !     /tmp/build_9429930b/vendor/bundle/ruby/3.0.0/gems/activesupport-6.1.4.1/lib/active_support/dependencies.rb:332:in `block in require'
remote:  !     /tmp/build_9429930b/vendor/bundle/ruby/3.0.0/gems/activesupport-6.1.4.1/lib/active_support/dependencies.rb:299:in `load_dependency'
remote:  !     /tmp/build_9429930b/vendor/bundle/ruby/3.0.0/gems/activesupport-6.1.4.1/lib/active_support/dependencies.rb:332:in `require'
remote:  !     /tmp/build_9429930b/vendor/bundle/ruby/3.0.0/gems/railties-6.1.4.1/lib/rails/generators.rb:6:in `<main>'
remote:  !     /tmp/build_9429930b/vendor/bundle/ruby/3.0.0/gems/bootsnap-1.7.2/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:23:in `require'
remote:  !     /tmp/build_9429930b/vendor/bundle/ruby/3.0.0/gems/bootsnap-1.7.2/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:23:in `block in require_with_bootsnap_lfi'
remote:  !     /tmp/build_9429930b/vendor/bundle/ruby/3.0.0/gems/bootsnap-1.7.2/lib/bootsnap/load_path_cache/loaded_features_index.rb:92:in `register'
remote:  !     /tmp/build_9429930b/vendor/bundle/ruby/3.0.0/gems/bootsnap-1.7.2/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:22:in `require_with_bootsnap_lfi'
remote:  !     /tmp/build_9429930b/vendor/bundle/ruby/3.0.0/gems/bootsnap-1.7.2/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:31:in `require'
remote:  !     /tmp/build_9429930b/vendor/bundle/ruby/3.0.0/gems/zeitwerk-2.5.4/lib/zeitwerk/kernel.rb:35:in `require'
remote:  !     /tmp/build_9429930b/vendor/bundle/ruby/3.0.0/gems/activesupport-6.1.4.1/lib/active_support/dependencies.rb:332:in `block in require'
remote:  !     /tmp/build_9429930b/vendor/bundle/ruby/3.0.0/gems/activesupport-6.1.4.1/lib/active_support/dependencies.rb:299:in `load_dependency'
remote:  !     /tmp/build_9429930b/vendor/bundle/ruby/3.0.0/gems/activesupport-6.1.4.1/lib/active_support/dependencies.rb:332:in `require'
remote:  !     /tmp/build_9429930b/vendor/bundle/ruby/3.0.0/gems/railties-6.1.4.1/lib/rails/app_updater.rb:3:in `<main>'
remote:  !     /tmp/build_9429930b/vendor/bundle/ruby/3.0.0/gems/bootsnap-1.7.2/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:23:in `require'
remote:  !     /tmp/build_9429930b/vendor/bundle/ruby/3.0.0/gems/bootsnap-1.7.2/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:23:in `block in require_with_bootsnap_lfi'
remote:  !     /tmp/build_9429930b/vendor/bundle/ruby/3.0.0/gems/bootsnap-1.7.2/lib/bootsnap/load_path_cache/loaded_features_index.rb:92:in `register'
remote:  !     /tmp/build_9429930b/vendor/bundle/ruby/3.0.0/gems/bootsnap-1.7.2/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:22:in `require_with_bootsnap_lfi'
remote:  !     /tmp/build_9429930b/vendor/bundle/ruby/3.0.0/gems/bootsnap-1.7.2/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:31:in `require'
remote:  !     /tmp/build_9429930b/vendor/bundle/ruby/3.0.0/gems/zeitwerk-2.5.4/lib/zeitwerk/kernel.rb:35:in `require'
remote:  !     /tmp/build_9429930b/vendor/bundle/ruby/3.0.0/gems/activesupport-6.1.4.1/lib/active_support/dependencies.rb:332:in `block in require'
remote:  !     /tmp/build_9429930b/vendor/bundle/ruby/3.0.0/gems/activesupport-6.1.4.1/lib/active_support/dependencies.rb:299:in `load_dependency'
remote:  !     /tmp/build_9429930b/vendor/bundle/ruby/3.0.0/gems/activesupport-6.1.4.1/lib/active_support/dependencies.rb:332:in `require'
remote:  !     /tmp/build_9429930b/vendor/bundle/ruby/3.0.0/gems/railties-6.1.4.1/lib/rails/tasks/framework.rake:41:in `block (2 levels) in <main>'
remote:  !     /tmp/build_9429930b/vendor/bundle/ruby/3.0.0/gems/rake-13.0.6/lib/rake/task_manager.rb:232:in `in_namespace'
remote:  !     /tmp/build_9429930b/vendor/bundle/ruby/3.0.0/gems/rake-13.0.6/lib/rake/dsl_definition.rb:141:in `namespace'
remote:  !     /tmp/build_9429930b/vendor/bundle/ruby/3.0.0/gems/railties-6.1.4.1/lib/rails/tasks/framework.rake:40:in `block in <main>'
remote:  !     /tmp/build_9429930b/vendor/bundle/ruby/3.0.0/gems/rake-13.0.6/lib/rake/task_manager.rb:232:in `in_namespace'
remote:  !     /tmp/build_9429930b/vendor/bundle/ruby/3.0.0/gems/rake-13.0.6/lib/rake/dsl_definition.rb:141:in `namespace'
remote:  !     /tmp/build_9429930b/vendor/bundle/ruby/3.0.0/gems/railties-6.1.4.1/lib/rails/tasks/framework.rake:3:in `<main>'
remote:  !     /tmp/build_9429930b/vendor/bundle/ruby/3.0.0/gems/bootsnap-1.7.2/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:77:in `load'
remote:  !     /tmp/build_9429930b/vendor/bundle/ruby/3.0.0/gems/bootsnap-1.7.2/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:77:in `load'
remote:  !     /tmp/build_9429930b/vendor/bundle/ruby/3.0.0/gems/activesupport-6.1.4.1/lib/active_support/dependencies.rb:326:in `block in load'
remote:  !     /tmp/build_9429930b/vendor/bundle/ruby/3.0.0/gems/activesupport-6.1.4.1/lib/active_support/dependencies.rb:299:in `load_dependency'
remote:  !     /tmp/build_9429930b/vendor/bundle/ruby/3.0.0/gems/activesupport-6.1.4.1/lib/active_support/dependencies.rb:326:in `load'
remote:  !     /tmp/build_9429930b/vendor/bundle/ruby/3.0.0/gems/railties-6.1.4.1/lib/rails/tasks.rb:18:in `block in <main>'
remote:  !     /tmp/build_9429930b/vendor/bundle/ruby/3.0.0/gems/railties-6.1.4.1/lib/rails/tasks.rb:17:in `each'
remote:  !     /tmp/build_9429930b/vendor/bundle/ruby/3.0.0/gems/railties-6.1.4.1/lib/rails/tasks.rb:17:in `<main>'
remote:  !     /tmp/build_9429930b/vendor/bundle/ruby/3.0.0/gems/bootsnap-1.7.2/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:59:in `load'
remote:  !     /tmp/build_9429930b/vendor/bundle/ruby/3.0.0/gems/bootsnap-1.7.2/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:59:in `load'
remote:  !     /tmp/build_9429930b/vendor/bundle/ruby/3.0.0/gems/activesupport-6.1.4.1/lib/active_support/dependencies.rb:326:in `block in load'
remote:  !     /tmp/build_9429930b/vendor/bundle/ruby/3.0.0/gems/activesupport-6.1.4.1/lib/active_support/dependencies.rb:299:in `load_dependency'
remote:  !     /tmp/build_9429930b/vendor/bundle/ruby/3.0.0/gems/activesupport-6.1.4.1/lib/active_support/dependencies.rb:326:in `load'
remote:  !     /tmp/build_9429930b/vendor/bundle/ruby/3.0.0/gems/railties-6.1.4.1/lib/rails/application.rb:529:in `run_tasks_blocks'
remote:  !     /tmp/build_9429930b/vendor/bundle/ruby/3.0.0/gems/railties-6.1.4.1/lib/rails/engine.rb:464:in `load_tasks'
remote:  !     /tmp/build_9429930b/Rakefile:6:in `<main>'
remote:  !     /tmp/build_9429930b/vendor/bundle/ruby/3.0.0/gems/bootsnap-1.7.2/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:59:in `load'
remote:  !     /tmp/build_9429930b/vendor/bundle/ruby/3.0.0/gems/bootsnap-1.7.2/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:59:in `load'
remote:  !     /tmp/build_9429930b/vendor/bundle/ruby/3.0.0/gems/rake-13.0.6/lib/rake/rake_module.rb:29:in `load_rakefile'
remote:  !     /tmp/build_9429930b/vendor/bundle/ruby/3.0.0/gems/rake-13.0.6/lib/rake/application.rb:710:in `raw_load_rakefile'
remote:  !     /tmp/build_9429930b/vendor/bundle/ruby/3.0.0/gems/rake-13.0.6/lib/rake/application.rb:104:in `block in load_rakefile'
remote:  !     /tmp/build_9429930b/vendor/bundle/ruby/3.0.0/gems/rake-13.0.6/lib/rake/application.rb:186:in `standard_exception_handling'
remote:  !     /tmp/build_9429930b/vendor/bundle/ruby/3.0.0/gems/rake-13.0.6/lib/rake/application.rb:103:in `load_rakefile'
remote:  !     /tmp/build_9429930b/vendor/bundle/ruby/3.0.0/gems/rake-13.0.6/lib/rake/application.rb:82:in `block in run'
remote:  !     /tmp/build_9429930b/vendor/bundle/ruby/3.0.0/gems/rake-13.0.6/lib/rake/application.rb:186:in `standard_exception_handling'
remote:  !     /tmp/build_9429930b/vendor/bundle/ruby/3.0.0/gems/rake-13.0.6/lib/rake/application.rb:80:in `run'
remote:  !     /tmp/build_9429930b/bin/rake:5:in `<main>'
remote:  !
```